### PR TITLE
0.9.1 -> 0.9.2

### DIFF
--- a/configs/network_pars/network_pars_example.yaml
+++ b/configs/network_pars/network_pars_example.yaml
@@ -8,6 +8,7 @@ training_dir: ../../xdisk/training_set_eft_2t_2z_hypersphere/
 # Location of config file with cosmology + bias parameters
 # This file contains all of the parameter ranges
 cosmo_dir : ./configs/cosmo_pars/cosmo_pars_2t_2z.yaml
+sampling_type : hypersphere
 
 model_type : stacked_transformer
 loss_type : hyperbolic_chi2

--- a/docs/examples/test_emulator.ipynb
+++ b/docs/examples/test_emulator.ipynb
@@ -706,8 +706,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "b260ff53",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 2]\n",
+      "[0.5]\n",
+      "[[0.000501]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "test_dir = \"/Users/JoeyA/Research/SPHEREx/spherex_emu/scripts/training_set_test/\"\n",
+    "\n",
+    "ps_properties = np.load(test_dir+\"ps_properties.npz\")\n",
+    "k = ps_properties[\"k\"]\n",
+    "ells = ps_properties[\"ells\"]\n",
+    "z_eff = ps_properties[\"z_eff\"]\n",
+    "ndens = ps_properties[\"ndens\"]\n",
+    "\n",
+    "print(ells)\n",
+    "print(z_eff)\n",
+    "print(ndens)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ff0aba4",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/docs/examples/test_emulator.ipynb
+++ b/docs/examples/test_emulator.ipynb
@@ -703,45 +703,6 @@
     "axs.legend()\n",
     "fig.subplots_adjust(hspace=0)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "b260ff53",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[0 2]\n",
-      "[0.5]\n",
-      "[[0.000501]]\n"
-     ]
-    }
-   ],
-   "source": [
-    "import numpy as np\n",
-    "test_dir = \"/Users/JoeyA/Research/SPHEREx/spherex_emu/scripts/training_set_test/\"\n",
-    "\n",
-    "ps_properties = np.load(test_dir+\"ps_properties.npz\")\n",
-    "k = ps_properties[\"k\"]\n",
-    "ells = ps_properties[\"ells\"]\n",
-    "z_eff = ps_properties[\"z_eff\"]\n",
-    "ndens = ps_properties[\"ndens\"]\n",
-    "\n",
-    "print(ells)\n",
-    "print(z_eff)\n",
-    "print(ndens)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6ff0aba4",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "spherex_emu"
 description = "package for emulating the galaxy power spectrum using neural networks"
-version = "0.9.1"
+version = "0.9.2"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [

--- a/scripts/get_powerspectra_eft.py
+++ b/scripts/get_powerspectra_eft.py
@@ -1,12 +1,12 @@
 import numpy as np
 
-import ps_theory_calculator
+import ps_theory_calculator_camb as ps_theory_calculator
 from spherex_emu.utils import prepare_ps_inputs, load_config_file
 
 def main():
-    pars_dir = "/home/joeadamo/Research/SPHEREx/spherex_emu/configs"
-    cosmo_dict = load_config_file(pars_dir+"/cosmo_pars/eft_2_tracer_2_redshift.yaml")
-    survey_pars = load_config_file(pars_dir+'/survey_pars/survey_pars_2_tracer_2_redshift.yaml')
+    pars_dir = "/Users/JoeyA/Research/SPHEREx/spherex_emu/configs"
+    cosmo_dict = load_config_file(pars_dir+"/cosmo_pars/cosmo_pars_1t_1z_corrected.yaml")
+    survey_pars = load_config_file(pars_dir+'/survey_pars/survey_pars_1_tracer_1_redshift.yaml')
 
     ndens_table = np.array([[float(survey_pars['number_density_in_hinvMpc_%s' % (i+1)][j]) for j in range(survey_pars['nz'])] for i in range(survey_pars['nsample'])])
     z_eff = (np.array(survey_pars["zbin_lo"]) + np.array(survey_pars["zbin_hi"])) / 2.
@@ -25,15 +25,17 @@ def main():
 
     param_vector = prepare_ps_inputs(alternate_params, cosmo_dict, ndens_table.shape[0], len(z_eff))
 
-    k_data = np.load('/home/joeadamo/Research/SPHEREx/covapt_mt/data/input_data/emulator/kbins.npz')
+    k_data = np.load('/Users/JoeyA/Research/Data/SPHEREx-Data/training_set_eft_1t_1z_hypersphere/kbins.npz')
     k = k_data["k"]
+    print(len(k))
     ells = [0, 2]
 
     theory = ps_theory_calculator.PowerSpectrumMultipole1Loop(ps_config)
     galaxy_ps = theory(k, ells, param_vector) / cosmo_dict["cosmo_params"]["h"]["value"]**3
-
     print(galaxy_ps.shape)
-    save_str = '/home/joeadamo/Research/Data/SPHEREx-Data/ps_camb.npy'
+    galaxy_ps = galaxy_ps.transpose(1, 0, 3, 2)
+    print(galaxy_ps.shape)
+    save_str = "/Users/JoeyA/Research/SPHEREx/Cosmo_Inference/src/spherex_cobaya/sample_data/ps_emu/ps_fid_1t_1z.npy"
     print("saving to: ", save_str)
     np.save(save_str, galaxy_ps)
 

--- a/scripts/make_training_set_eft.py
+++ b/scripts/make_training_set_eft.py
@@ -1,12 +1,9 @@
 # This script generates a training set for the spherex emulator based on Yosuke's EFT power spectrum model
 # Utilizing an embarrasingly parallel code structure
 
-import time, math, yaml, sys
+import time, math, yaml, sys, os
 import numpy as np
 from mpi4py import MPI
-
-from scipy.integrate import romb
-from scipy.special import lpmv
 
 import ps_theory_calculator_camb as ps_theory_calculator
 from spherex_emu.utils import *
@@ -163,8 +160,8 @@ def main():
         print("Generating fiducial power spectrum...")
         galaxy_ps, result = get_power_spectrum([{}], k, param_names, cosmo_dict, ps_config, theory)
         if result == 0:
-            np.save(save_dir+"ps_fid.npy", galaxy_ps)
-            np.savez(save_dir+"kbins.npz", k=k)
+            np.save(os.path.join(save_dir,"ps_fid.npy"), galaxy_ps)
+            np.savez(os.path.join(save_dir,"ps_properties.npz"), k=k, z_eff=z_eff, ells=np.array(ells), ndens=ndens_table)
         else:
             print("ERROR! failed to calculate fiducial power spectrum! Exiting...")
             return -1
@@ -187,10 +184,10 @@ def main():
     dataset_info = prepare_header_info(param_names, cosmo_dict, N - fail_compute)
 
     if galaxy_ps.shape[0] > 1:
-        np.savez(save_dir+"pk-raw_"+str(rank)+"_.npz", params=rank_samples, galaxy_ps=galaxy_ps)
+        np.savez(os.path.join(save_dir,"pk-raw_"+str(rank)+"_.npz"), params=rank_samples, galaxy_ps=galaxy_ps)
     
     if rank == 0:
-        with open(save_dir+'info.yaml', 'w') as outfile:
+        with open(os.path.join(save_dir,'info.yaml'), 'w') as outfile:
             yaml.dump(dataset_info, outfile, sort_keys=False, default_flow_style=False)
 
     del galaxy_ps

--- a/src/spherex_emu/dataset.py
+++ b/src/spherex_emu/dataset.py
@@ -55,6 +55,7 @@ class pk_galaxy_dataset(torch.utils.data.Dataset):
             self.params = self.params[0:N_frac]
             self.galaxy_ps = self.galaxy_ps[0:N_frac]
 
+
     def __len__(self):
         """Returns the number of samples in the dataset
 
@@ -63,6 +64,7 @@ class pk_galaxy_dataset(torch.utils.data.Dataset):
         """
         return self.params.shape[0]
     
+
     def __getitem__(self, idx):
         """Returns specific items from the dataset
 
@@ -88,7 +90,7 @@ class pk_galaxy_dataset(torch.utils.data.Dataset):
         self.galaxy_ps = self.galaxy_ps.to(device)
     
 
-    def normalize_data(self, ps_fid:torch.Tensor, ps_nw_fid:torch.Tensor, sqrt_eigvals:torch.Tensor, Q:torch.Tensor):
+    def normalize_data(self, ps_fid:torch.Tensor, sqrt_eigvals:torch.Tensor, Q:torch.Tensor):
         """Normalizes the reshapes the data
 
         Args:

--- a/src/spherex_emu/emulator.py
+++ b/src/spherex_emu/emulator.py
@@ -14,7 +14,7 @@ from spherex_emu.dataset import pk_galaxy_dataset
 from spherex_emu.utils import load_config_file, get_parameter_ranges,\
                               normalize_cosmo_params, un_normalize_power_spectrum, \
                               delta_chi_squared, mse_loss, hyperbolic_loss, hyperbolic_chi2_loss, \
-                              get_invcov_blocks, get_full_invcov, pca_inverse_transform
+                              get_invcov_blocks, get_full_invcov, pca_inverse_transform, is_in_hypersphere
 
 class ps_emulator():
     """Class defining the neural network emulator."""
@@ -38,15 +38,15 @@ class ps_emulator():
         if net_dir.endswith(".yaml"): self.config_dict = load_config_file(net_dir)
         else:                         self.config_dict = load_config_file(os.path.join(net_dir,"config.yaml"))
 
-        # HACK: force normalization_type variable to be defined for older models
-        self.normalization_type = "normal"
-
         self.logger = logging.getLogger('ps_emulator')
+
+        # TODO: Remove this when removing PCA stuff
+        self.normalization_type = "normal"
+        self.config_dict["normalization_type"] = "normal"
 
         # load dictionary entries into their own class variables
         for key in self.config_dict:
             setattr(self, key, self.config_dict[key])
-        self.config_dict["normalization_type"] = self.normalization_type
 
         self._init_device(device, mode)
         self._init_model()
@@ -85,8 +85,9 @@ class ps_emulator():
 
         input_norm_data = torch.load(os.path.join(path,"input_normalizations.pt"), 
                                      map_location=self.device, weights_only=True)
-        self.input_normalizations = input_norm_data[0]
+        self.input_normalizations = input_norm_data[0] # <- in shape expected by networks
         self.required_emu_params  = input_norm_data[1]
+        self.emu_param_bounds     = input_norm_data[2]
 
         ps_properties = np.load(os.path.join(path, "ps_properties.npz"))
         self.k_emu = ps_properties["k"]
@@ -163,15 +164,17 @@ class ps_emulator():
             raise KeyError("Invalid value for key! must be one of ['training', 'validation', 'testing']")
 
 
-    def get_power_spectra(self, params, raw_output:bool = False):
+    def get_power_spectra(self, params, extrapolate:bool = False, raw_output:bool = False):
         """Gets the full galaxy power spectrum multipoles (emulated and analytically calculated)
         
         Args:
             params: 1D or 2D numpy array, torch Tensor, or dictionary containing a list of cosmology + galaxy bias parameters. 
                 if params is a 2D array, this function generates a batch of power spectra simultaniously
+            extrapolate (bool): Whether or not to pass through the emulator if the given input parameters are outside the range it was trained on.
+                Default False
             raw_output: bool specifying whether or not to return the raw network output without undoing normalization. Default False
         """
-        galaxy_ps_emu = self.get_emulated_power_spectrum(params, raw_output)
+        galaxy_ps_emu = self.get_emulated_power_spectrum(params, raw_output, extrapolate)
 
         if galaxy_ps_emu.shape[0] == 1: 
             return galaxy_ps_emu[0] + self.analytic_model.get_analytic_terms(params, self.required_emu_params, self.get_required_analytic_parameters())
@@ -179,18 +182,30 @@ class ps_emulator():
             return galaxy_ps_emu
 
 
-    def get_emulated_power_spectrum(self, params, raw_output:bool = False):
+    def get_emulated_power_spectrum(self, params, extrapolate:bool = False, raw_output:bool = False):
         """Gets the power spectra corresponding to the given input params by passing them though the emulator
         
         Args:
             params: 1D or 2D numpy array, torch Tensor, or dictionary containing a list of cosmology + galaxy bias parameters. 
-                if params is a 2D array, this function generates a batch of power spectra simultaniously
+            if params is a 2D array, this function generates a batch of power spectra simultaniously
+            extrapolate (bool): Whether or not to pass through the emulator if the given input parameters are outside the range it was trained on.
+            Default False
             raw_output: bool specifying whether or not to return the raw network output without undoing normalization. Default False
+
+        Returns:
+            galaxy_ps (np.array): emulated galaxy power spectrum multipoles (P_tree + P_1loop). If given a batch of parameters, has shape [nb, nps, nz, nk, nl]. 
+            Otherwise, has shape [nps, nz, nk, nl]. If extrapolate is false and the given input parameters are out of bounds, then this function returns
+            an array of all zeros.
         """
         
         self.galaxy_ps_model.eval()
         with torch.no_grad():
-            emu_params = self._check_params(params)
+            emu_params, skip_emulation = self._check_params(params, extrapolate)
+            if skip_emulation and params.shape[0] == 1:
+                return np.zeros((self.num_spectra, self.num_zbins, self.num_kbins, self.num_ells))
+            elif skip_emulation and params.shape[0] > 1:
+                return np.zeros((params.shape[0], self.num_spectra, self.num_zbins, self.num_kbins, self.num_ells))
+
             galaxy_ps = self.galaxy_ps_model.forward(emu_params) # <- shape [nb, nps, nz, nk*nl]
             
             if raw_output:
@@ -210,13 +225,32 @@ class ps_emulator():
 
 
     def get_required_emu_parameters(self):
-        """Returns a dictionary of input parameters needed by the emulator. Used within Cosmo_Inference"""
+        """Returns a list of input parameters needed by the emulator. 
+        
+        Currently, spherex_emu requires input parameters to be in the same order as given by
+        the return value of this function. For example. If the return list is ['h', 'omch2'], you
+        should pass in [h, omch2] to get_power_spectra in that order.
+        
+        Returns:
+            required_emu_params (list): list of input cosmology + bias parameters required by the emulator.
+        """
         return self.required_emu_params
 
 
     def get_required_analytic_parameters(self):
-        # TODO: find a better way to do this
-        return ["counterterm_0", "counterterm_2", "counterterm_fog", "P_shot"]
+        """Returns a list of input parameters used by our analytic eft model, not directly emulated.
+        
+        NOTE: These parameters are currently hard-coded.
+
+        Returns:
+            required_analytic_params (list): list of input (counterterm + stoch) parameters.
+        """
+        analytic_params = []
+        if 0 in self.ells:  analytic_params.append("counterterm_0")
+        if 2 in self.ells:  analytic_params.append("counterterm_2")
+        if 4 in self.ells:  analytic_params.append("counterterm_4")
+        analytic_params.extend(["counterterm_fog", "P_shot"])
+        return analytic_params
 
 
     def check_kbins_are_compatible(self, test_kbins:np.array):
@@ -271,7 +305,7 @@ class ps_emulator():
         """
 
         try:
-            cosmo_dict = load_config_file(self.input_dir+self.cosmo_dir)
+            cosmo_dict = load_config_file(os.path.join(self.input_dir,self.cosmo_dir))
             param_names, param_bounds = get_parameter_ranges(cosmo_dict)
             input_normalizations = torch.Tensor(param_bounds.T).to(self.device)
         except IOError:
@@ -283,6 +317,8 @@ class ps_emulator():
         upper_bounds = self.galaxy_ps_model.organize_parameters(input_normalizations[1].unsqueeze(0))
         self.input_normalizations = torch.vstack([lower_bounds, upper_bounds])
         self.required_emu_params = param_names
+        self.emu_param_bounds = torch.from_numpy(param_bounds).to(torch.float32).to(self.device)
+
 
     def _init_pca(self, data:pk_galaxy_dataset):
         """Transforms the given dataset to its corresponding princpiple components"""
@@ -465,7 +501,7 @@ class ps_emulator():
             self.logger.warning("power spectrum properties not initialized!")
 
         # data related to input normalization
-        input_files = [self.input_normalizations, self.required_emu_params]
+        input_files = [self.input_normalizations, self.required_emu_params, self.emu_param_bounds]
         torch.save(input_files, os.path.join(save_dir, "input_normalizations.pt"))
         with open(os.path.join(save_dir, "param_names.txt"), "w") as outfile:
             yaml.dump(self.get_required_emu_parameters(), outfile, sort_keys=False, default_flow_style=False)
@@ -481,8 +517,9 @@ class ps_emulator():
         torch.save(self.galaxy_ps_checkpoint, os.path.join(save_dir, 'network_galaxy.params'))
 
 
-    def _check_params(self, params):
+    def _check_params(self, params, extrapolate=False):
         """checks that input parameters are in the expected format and within the specified boundaries"""
+        skip_emulation = False
 
         if isinstance(params, torch.Tensor): 
             params = params.to(self.device)
@@ -496,14 +533,21 @@ class ps_emulator():
         if params.shape[1] > len(self.required_emu_params):
             params = params[:, :len(self.required_emu_params)]
 
-        params = self.galaxy_ps_model.organize_parameters(params)
+        org_params = self.galaxy_ps_model.organize_parameters(params)
 
-        if torch.any(params < self.input_normalizations[0]) or \
-           torch.any(params > self.input_normalizations[1]):
-            self.logger.warning("Input parameters out of bounds! Emulator output will be untrustworthy:")
-        
-        norm_params = normalize_cosmo_params(params, self.input_normalizations)
-        return norm_params
+        if (self.sampling_type == "hypercube" and \
+            torch.any(org_params < self.input_normalizations[0]) or \
+            torch.any(org_params > self.input_normalizations[1])) or \
+           (self.sampling_type == "hypersphere" and \
+            not is_in_hypersphere(self.emu_param_bounds, params)[0]):
+            if extrapolate:
+                self.logger.warning("Input parameters out of bounds! Emulator output will be untrustworthy:")
+            else: 
+                self.logger.info("Input parameters out of bounds! Skipping emulation...")
+                skip_emulation = True
+
+        norm_params = normalize_cosmo_params(org_params, self.input_normalizations)
+        return norm_params, skip_emulation
 
     def _check_training_set(self, data:pk_galaxy_dataset):
         """checks that loaded-in data for training / validation / testing is compatable with the given network config
@@ -553,15 +597,13 @@ def compile_multiple_device_training_results(save_dir:str, config_dir:str, num_g
         sub_dir = "rank_"+str(n)
         seperate_network = ps_emulator(os.path.join(save_dir,sub_dir), "eval")
 
-        # non-wiggle power spectrum network + kbins
+        # power spectrum properties used by analytic_terms.py
         if n == 0:
             ps_properties = np.load(os.path.join(save_dir, sub_dir, "ps_properties.npz"))
             full_emulator.k_emu = ps_properties["k"]
             full_emulator.ells = ps_properties["ells"]
             full_emulator.z_eff = ps_properties["z_eff"]
             full_emulator.ndens = ps_properties["ndens"]
-            train_data = torch.load(os.path.join(save_dir,sub_dir,"training_statistics/train_data_nw.dat"), weights_only=True)
-            full_emulator.nw_train_loss = train_data[0,:]
 
         # galaxy power spectrum networks
         for (ps, z) in split_indices[n]:

--- a/src/spherex_emu/models/stacked_mlp.py
+++ b/src/spherex_emu/models/stacked_mlp.py
@@ -30,10 +30,7 @@ class single_mlp(nn.Module):
         else:
             self.input_dim = config_dict["num_cosmo_params"] + (2 * config_dict["num_nuisance_params"])
 
-        if config_dict["normalization_type"] == "normal":
-            self.output_dim = self.num_ells * self.num_kbins
-        elif config_dict["normalization_type"] == "pca":
-            self.output_dim = config_dict["num_pcs"]
+        self.output_dim = self.num_ells * self.num_kbins
 
         # mlp blocks
         self.input_layer = nn.Linear(self.input_dim, self.output_dim)
@@ -83,10 +80,7 @@ class stacked_mlp(nn.Module):
         self.num_cosmo_params = config_dict["num_cosmo_params"]
         self.num_nuisance_params = config_dict["num_nuisance_params"]
 
-        if config_dict["normalization_type"] == "normal":
-            self.output_dim = self.num_ells * self.num_kbins
-        elif config_dict["normalization_type"] == "pca":
-            self.output_dim = config_dict["num_pcs"]
+        self.output_dim = self.num_ells * self.num_kbins
 
         # Stores networks sequentially in a list
         self.networks = nn.ModuleList()

--- a/src/spherex_emu/models/stacked_transformer.py
+++ b/src/spherex_emu/models/stacked_transformer.py
@@ -30,11 +30,7 @@ class single_transformer(nn.Module):
         else:
             self.input_dim = config_dict["num_cosmo_params"] + (2 * config_dict["num_nuisance_params"])
         
-        
-        if config_dict["normalization_type"] == "normal":
-            self.output_dim = self.num_ells * self.num_kbins
-        elif config_dict["normalization_type"] == "pca":
-            self.output_dim = config_dict["num_pcs"]
+        self.output_dim = self.num_ells * self.num_kbins
 
         # mlp blocks
         self.input_layer = nn.Linear(self.input_dim, self.output_dim)
@@ -100,10 +96,7 @@ class stacked_transformer(nn.Module):
         self.num_cosmo_params    = config_dict["num_cosmo_params"]
         self.num_nuisance_params = config_dict["num_nuisance_params"]
 
-        if config_dict["normalization_type"] == "normal":
-            self.output_dim = self.num_ells * self.num_kbins
-        elif config_dict["normalization_type"] == "pca":
-            self.output_dim = config_dict["num_pcs"]
+        self.output_dim = self.num_ells * self.num_kbins
 
         # Stores networks sequentially in a list
         self.networks = nn.ModuleList()

--- a/src/spherex_emu/training_loops.py
+++ b/src/spherex_emu/training_loops.py
@@ -5,7 +5,7 @@ import logging
 import os
 
 from spherex_emu.emulator import ps_emulator, compile_multiple_device_training_results
-from spherex_emu.utils import calc_avg_loss, normalize_cosmo_params, pca_inverse_transform
+from spherex_emu.utils import calc_avg_loss, normalize_cosmo_params
 
 
 def train_galaxy_ps_one_epoch(emulator:ps_emulator, train_loader:torch.utils.data.DataLoader, bin_idx:list):
@@ -35,12 +35,7 @@ def train_galaxy_ps_one_epoch(emulator:ps_emulator, train_loader:torch.utils.dat
         prediction = emulator.galaxy_ps_model.forward(params, net_idx)
         
         # calculate loss and update network parameters
-        # TODO: Find better way to deal with passing invcov to the loss function
-        if emulator.normalization_type == "pca":
-            prediction = pca_inverse_transform(prediction, emulator.principle_components, emulator.training_set_variance)
-            loss = emulator.loss_function(prediction, target, emulator.invcov_blocks[ps_idx, z_idx], False)
-        else:
-            loss = emulator.loss_function(prediction, target, emulator.invcov_full, True)
+        loss = emulator.loss_function(prediction, target, emulator.invcov_full, True)
 
         assert torch.isnan(loss) == False
         assert torch.isinf(loss) == False

--- a/src/spherex_emu/utils.py
+++ b/src/spherex_emu/utils.py
@@ -173,10 +173,20 @@ def is_in_hypersphere(priors, params):
     """Returns whether or not the given params are within a hypersphere with edges defined by bounds"""
 
     # convert params to lay within the unit sphere
-    unit_params = np.zeros_like(params)
+    if isinstance(params, torch.Tensor):
+        unit_params = torch.zeros_like(params)
+        calc_method = torch
+    elif isinstance(params, np.ndarray):
+        unit_params = np.zeros_like(params)
+        calc_method = np
+
     for d in range(priors.shape[0]):
-        unit_params[d] = 2*(params[d] - priors[d,0]) / (priors[d,1] - priors[d,0]) - 1
-    r = np.sqrt(np.sum(unit_params**2))
+        if len(params.shape) == 1:
+            unit_params[d] = 2*(params[d] - priors[d,0]) / (priors[d,1] - priors[d,0]) - 1
+        elif len(params.shape) == 2:
+            unit_params[:,d] = 2*(params[:,d] - priors[d,0]) / (priors[d,1] - priors[d,0]) - 1
+    
+    r = calc_method.sqrt(calc_method.sum(unit_params**2))
     if r >= 1: return False, r
     else:      return True, r
 

--- a/src/spherex_emu/utils.py
+++ b/src/spherex_emu/utils.py
@@ -438,26 +438,9 @@ def calc_avg_loss(emulator, data_loader, loss_function:callable, bin_idx=None, m
             else:
                 raise KeyError(f"Invalid value for mode ({mode})")
 
-            if emulator.normalization_type == "pca":
-                prediction = pca_inverse_transform(prediction, emulator.principle_components, emulator.training_set_variance)
-                avg_loss += loss_function(prediction, target, emulator.invcov_blocks[bin_idx], False).item()
-            else:
-                avg_loss += loss_function(prediction, target, emulator.invcov_blocks, True).item()
+            avg_loss += loss_function(prediction, target, emulator.invcov_blocks, True).item()
 
     return avg_loss / (len(data_loader.dataset))
-
-
-def pca_transform(data, components, std):
-    """Performs a PCA transformation (NOTE: Unused function currently)"""
-    return (data / std) @ components.T
-
-
-def pca_inverse_transform(reduced_data:torch.Tensor, components, std):
-    """Performs a reverse PCA transformation (NOTE: Unused function currently)"""
-    if reduced_data.dim() == 2:
-        reduced_data = reduced_data.unsqueeze(1)
-
-    return (torch.matmul(reduced_data, components) * std).squeeze()
 
 
 def normalize_cosmo_params(params:torch.Tensor, normalizations:torch.Tensor):

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -87,5 +87,3 @@ def test_stacked_transformer_network():
                                          test_emulator.num_zbins,
                                          test_emulator.num_kbins*test_emulator.num_ells)
     assert torch.allclose(test_output_sub, test_output_full[:,0,0])
-
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import torch
 import pytest
+import numpy as np
+from spherex_emu.emulator import ps_emulator
 from spherex_emu.utils import *
 
 def test_normalize_cosmo_params():
@@ -82,3 +84,28 @@ def test_get_invcov_blocks(num_spectra, num_zbins, num_kbins, num_ells):
     invcov_blocks = get_invcov_blocks(test_cov, num_spectra, num_zbins, num_kbins, num_ells)
     assert invcov_blocks.shape == (num_spectra, num_zbins, num_ells*num_kbins, num_ells*num_kbins)
     
+@pytest.mark.parametrize("factor, type, expected",[
+    (0.5, "np", True),
+    (0.6, "torch", True),
+    (1.0, "torch", False)
+])
+def test_is_in_hypersphere(factor, type, expected):
+
+    current_dir = os.path.dirname(os.path.realpath(__file__))
+    test_cosmo_dir = current_dir+"/../configs/cosmo_pars/cosmo_pars_example.yaml"
+
+    cosmo_dict = load_config_file(test_cosmo_dir)
+    param_names, param_bounds = get_parameter_ranges(cosmo_dict)
+    
+    if type == "np":
+        test_params = np.ones(len(param_names)) * factor
+    elif type == "torch":
+        test_params = torch.ones(len(param_names)) * factor
+        param_bounds = torch.from_numpy(param_bounds)
+    test_params = test_params * (param_bounds[:,1] - param_bounds[:,0]) + param_bounds[:,0]
+
+    result, r = is_in_hypersphere(param_bounds, test_params)
+
+    assert result == expected
+    if result == False:
+        assert r > 1.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,9 +15,10 @@ def test_normalize_cosmo_params():
     assert torch.allclose(manual_norm_tensor, norm_tensor)
     assert torch.allclose(test_tensor, unnorm_tensor)
 
+# TODO: This test is wildly inconsistent
 def test_normalize_power_spectra():
     
-    test_fid_tensor = (torch.rand((3, 2, 2*25)) * 100) - 25
+    test_fid_tensor = (torch.ones((3, 2, 2*25)) * 100) - 25
 
     test_cov = torch.rand(3, 2, 2*25, 2*25)
     test_eigvals = torch.zeros((3, 2, 2*25))
@@ -32,15 +33,14 @@ def test_normalize_power_spectra():
             test_Q[i,j] = q.real
             test_Q_inv[i,j] = torch.linalg.inv(q).real
 
-    for n in range(50):
-        test_tensor = (torch.rand((1, 3, 2, 2*25)) * 100) - 25
+    test_tensor = (torch.ones((1, 3, 2, 2*25)) * 100) - 15
 
-        norm_tensor = normalize_power_spectrum(test_tensor, test_fid_tensor, test_eigvals, test_Q)
-        unnorm_tensor = un_normalize_power_spectrum(norm_tensor, test_fid_tensor, test_eigvals, test_Q, test_Q_inv)
+    norm_tensor = normalize_power_spectrum(test_tensor, test_fid_tensor, test_eigvals, test_Q)
+    unnorm_tensor = un_normalize_power_spectrum(norm_tensor, test_fid_tensor, test_eigvals, test_Q, test_Q_inv)
 
-        # numerical errors from normalization process expected to be higher than floating point percision
-        assert torch.all(torch.isnan(norm_tensor)) == False
-        assert torch.amax((test_tensor - unnorm_tensor) / test_tensor) < 0.075
+    # numerical errors from normalization process expected to be higher than floating point percision
+    assert torch.all(torch.isnan(norm_tensor)) == False
+    assert torch.amax((test_tensor - unnorm_tensor) / test_tensor) < 0.075
 
 
 def test_get_parameter_ranges():


### PR DESCRIPTION
This PR implements the following changes:

1. Removed old PCA code (potentially will be added back in in a future release).
2. Added more power spectrum properties for emulator.py to keep track of, now saved in ps_properties.npz, specifically 
a. the effective redshift for each bin
b. the number density for each bin
c. parameter bounds in a more usable format
4. Added a check in _check_params() for if the given parameters lie within a hypersphere
5. Added a config option in the net config file specifying sampling strategy (currently "hypercube" or "hypersphere")
6. Added a few more unit tests